### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=See individual Source Files
 maintainer=Kidelo
 sentence=Some code snippets for ATMEL / arduino based boards
 paragraph=Some code snippets for ATMEL / arduino based boards
-category=Utils
+category=Other
 url=https://github.com/kidelo/Arduino_Utils.git
 architectures=*


### PR DESCRIPTION
The previous caused the following warning to be displayed on every compilation:

WARNING: Category 'Utils' in library Arduino_Utils is not valid. Setting to 'Uncategorized'

List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format